### PR TITLE
✨ Quality: File streams not properly disposed on preview failure

### DIFF
--- a/FileExplorer.Extension.RichTextPreview/RichTextViewer.xaml.cs
+++ b/FileExplorer.Extension.RichTextPreview/RichTextViewer.xaml.cs
@@ -36,7 +36,17 @@ namespace FileExplorer.Extension.RichTextPreview
         public Task PreviewFile(string filePath)
         {
             ZoomFactor = 100f;
-            Document = File.Open(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+            Stream stream = null;
+            try
+            {
+                stream = File.Open(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+                Document = stream;
+            }
+            catch
+            {
+                stream?.Dispose();
+                throw;
+            }
 
             return Task.CompletedTask;
         }


### PR DESCRIPTION
## Problem

The `PreviewFile` method opens a file stream with `File.Open()` but doesn't handle exceptions.
If an exception occurs after opening the stream but before assignment to the `Document` property,
the stream will leak. This is a resource leak that could cause file locking issues or
exhaust file handles over time, especially when previewing problematic files.


**Severity**: `medium`
**File**: `FileExplorer.Extension.RichTextPreview/RichTextViewer.xaml.cs`

## Solution

Wrap the file opening in a try-catch block to ensure proper disposal:


## Changes

- `FileExplorer.Extension.RichTextPreview/RichTextViewer.xaml.cs` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
